### PR TITLE
Loosen Java cookbook version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jwharrison007@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures Vanilla, Spigot, Bungeecord, and Bukkit Minecraft servers'
 long_description 'Installs/Configures Vanilla, Spigot, Bungeecord, and Bukkit Minecraft servers'
-version '0.1.4'
+version '0.1.5'
 
 depends 'java', '~> 1'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures Vanilla, Spigot, Bungeecord, and Bukkit Minecra
 long_description 'Installs/Configures Vanilla, Spigot, Bungeecord, and Bukkit Minecraft servers'
 version '0.1.4'
 
-depends 'java', '~> 1.42.0'
+depends 'java', '~> 1'
 
 source_url 'https://github.com/Mac-Genius/minecraft-server'
 issues_url 'https://github.com/Mac-Genius/minecraft-server/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures Vanilla, Spigot, Bungeecord, and Bukkit Minecra
 long_description 'Installs/Configures Vanilla, Spigot, Bungeecord, and Bukkit Minecraft servers'
 version '0.1.5'
 
-depends 'java', '~> 1'
+depends 'java', '~> 1.42'
 
 source_url 'https://github.com/Mac-Genius/minecraft-server'
 issues_url 'https://github.com/Mac-Genius/minecraft-server/issues'


### PR DESCRIPTION
1.50.0 of the java cookbook works again with Oracle download.  

The previous constrain only matched agains 1.42.X (See, https://github.com/chef/chef/blob/master/spec/unit/version_constraint_spec.rb#L132-L149) but new constraint works for 1.X from 1.42 and 1.9999.3 and so on.